### PR TITLE
Create multiple Nightmare.js instances

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,51 +5,40 @@ import Nightmare from 'nightmare';
 import debug from 'debug';
 
 export default {
-    // reference to Nightmare instance
-    nightmare: null,
-
     // map with open page references
-    openedPages: {},
+    nightmareInstances: {},
 
     // multiple browsers support
     isMultiBrowser: false,
 
     // open new page in browser
     async openBrowser (id, pageUrl) {
-        const page = await this.nightmare.goto(pageUrl);
-
-        this.openedPages[id] = page;
-    },
-
-    // close given page in browser
-    async closeBrowser (id) {
-        const page = this.openedPages[id];
-
-        delete this.openedPages[id];
-        await page.end();
-    },
-
-    // init browser
-    async init () {
         const conf = {
             show:         debug.enabled(),
             openDevTools: debug.enabled(),
         };
 
-        this.nightmare = Nightmare(conf);
+        this.nightmareInstances[id] = Nightmare(conf);
+
+        await this.nightmareInstances[id].goto(pageUrl);
     },
 
-    async dispose () {
-        return;
+    // close given page in browser
+    async closeBrowser (id) {
+        const nightmare = this.nightmareInstances[id];
+
+        delete this.nightmareInstances[id];
+
+        await nightmare.end();
     },
 
     // resize browser window to given size
     async resizeWindow (id, width, height) {
-        await this.nightmare.viewport(width, height);
+        await this.nightmareInstances[id].viewport(width, height);
     },
 
     // take screenshot of given page in browser
     async takeScreenshot (id, screenshotPath) {
-        await this.nightmare.screenshot(screenshotPath);
+        await this.nightmareInstances[id].screenshot(screenshotPath);
     }
 };


### PR DESCRIPTION
This change is needed because:

 1. The `page.end()` call in `closeBrowser`  doesn't actually closes Nightmare process. Because `page` is just chaine-enabled Promise, and it becomes invalid after any other call to the Nightmare API. https://github.com/DevExpress/testcafe/issues/1493

 2. One Nightmare instance for all pages doesn't work in the new [Concurrent Test Execution mode](https://devexpress.github.io/testcafe/documentation/using-testcafe/common-concepts/concurrent-test-execution.html)